### PR TITLE
Ensure that forward slashes in predicates are not counted as part of the URL

### DIFF
--- a/src/main/java/com/yellowbkpk/geo/xapi/servlet/XapiServlet.java
+++ b/src/main/java/com/yellowbkpk/geo/xapi/servlet/XapiServlet.java
@@ -65,7 +65,15 @@ public class XapiServlet extends HttpServlet {
                     urlBuffer.append("?").append(request.getQueryString());
                 }
                 String reqUrl = urlBuffer.toString();
-                String query = reqUrl.substring(reqUrl.lastIndexOf('/') + 1);
+
+		// this ensures that slashes inside any predicate block aren't counted as
+		// part of the URL, for example when other URLs are used in tag queries.
+		int predicateBegin = reqUrl.indexOf('[');
+		if (predicateBegin < 0) {
+		   predicateBegin = reqUrl.length();
+		}
+
+                String query = reqUrl.substring(reqUrl.lastIndexOf('/', predicateBegin) + 1);
                 query = URLDecoder.decode(query, "UTF-8");
 
                 if (XapiQueryStats.isQueryAlreadyRunning(query, request.getRemoteHost())) {

--- a/src/test/java/com/yellowbkpk/geo/xapi/query/XAPIQueryInfoTest.java
+++ b/src/test/java/com/yellowbkpk/geo/xapi/query/XAPIQueryInfoTest.java
@@ -331,6 +331,9 @@ public class XAPIQueryInfoTest {
         // check that @s at the beginning can be escaped without being
         // interpreted as an attribute selector
         assertDoesParseTag("*[\\@foobar=something]", "@foobar", "something");
+
+	// check that URLs parse in the tag value
+	assertDoesParseTag("node[source=http:\\/\\/www.ncdc.noaa.gov\\/nexradinv\\/]", "source", "http://www.ncdc.noaa.gov/nexradinv/");
     }
 
     @Test


### PR DESCRIPTION
This happens when URLs themselves used as parts of the query. For example:

 node[source=http://www.ncdc.noaa.gov/nexradinv/]

As mentioned in http://developer.mapquest.com/web/products/open/forums/-/message_boards/view_message/223153
