### PR TITLE
Access logging

### DIFF
--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context>
+  <Valve className="org.apache.catalina.valves.AccessLogValve"
+         prefix="xapi_access_log." suffix=".txt" pattern="combined" />
+</Context>


### PR DESCRIPTION
This will turn on a "combined" style access log for the xapi application. By default the file is rotated on a daily basis. This can be changed with the fileDateFormat attribute as documented at http://tomcat.apache.org/tomcat-7.0-doc/config/valve.html#Access%20Log%20Valve

The way tomcat handles this seems odd to me. The first time it deploys a WAR with a context.xml file in it, it takes the context.xml file from the WAR file and copies it to $TOMCAT/conf/Catalina/localhost/xapi.xml. Apparently this is a one-time thing. Any changes to context.xml in future WAR files will **not** be copied over the existing one in the conf directory. (source: http://tomcat.apache.org/tomcat-7.0-doc/config/host.html#Standard_Implementation )

I just verified that this "just works" on a brand new install of tomcat 7 from apache.org. Some changes in server configuration could break it in which case the access log just won't be created. Specifically, tomcat can be told to ignore context.xml files from WAR files for security reasons. In this case the administrator can manually copy the file into the tomcat conf directory as detailed above.
