### PR TITLE
Add postgresql 9.1 specific hstore information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ These setup steps assume you're working on a Ubuntu 9.x/10.x installation.
     
     `psql -d xapi -f /usr/share/postgresql/8.4/contrib/hstore-new.sql`
     
+    Under postgresql 9.1 install the package postgresql-contrib-9.1 and run the command psql -d xapi -c "CREATE EXTENSION hstore"
+    
     `psql -d xapi -f ~/osmosis/package/script/pgsnapshot_schema_0.6.sql`
     
     `psql -d xapi -f ~/osmosis/package/script/pgsnapshot_schema_0.6_linestring.sql`


### PR DESCRIPTION
postgresql changed how extensions are set up in 9.1. Also, hstore-new has been essentially merged into hstore. I have not tested loading a DB into 9.1 yet, but the setup tasks run correctly
