### PR TITLE
Change commons-dbcp to a compile-time dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 			<groupId>commons-dbcp</groupId>
 			<artifactId>commons-dbcp</artifactId>
 			<version>1.4</version>
-			<scope>test</scope>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
Tomcat, as packaged by Ubuntu, seems to provide this but it can't be relied upon in other environments.

For example, without this it fails to run on a vanilla tomcat install downloaded from apache.org. The error is rather annoying to track down since it presents as a NullPointerException.
