### PR TITLE
Adding compatibility for the way the main API lets you query a list of objects

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -35,6 +35,9 @@
     <url-pattern>/api/0.6/node/*</url-pattern>
     <url-pattern>/api/0.6/way/*</url-pattern>
     <url-pattern>/api/0.6/relation/*</url-pattern>
+    <url-pattern>/api/0.6/nodes</url-pattern>
+    <url-pattern>/api/0.6/ways</url-pattern>
+    <url-pattern>/api/0.6/relations</url-pattern>
   </servlet-mapping>
   
   <servlet>


### PR DESCRIPTION
Lets the ApiServlet answer queries like /api/0.6/nodes?nodes=1,2,3 in addition to the existing /api/0.6/node/1,2,3 method.
